### PR TITLE
Enhance HTML escaping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ const RIGHT = '-->';
 const ENCODE = [
   ['&', '&amp;'],
   ['>', '&gt;'],
+  ['<', '&lt;'],
+  ['/', '&#47;'],
 ];
 
 const DATA_KEY = 'hypernova-key';

--- a/test/escape-test.js
+++ b/test/escape-test.js
@@ -7,7 +7,7 @@ describe('escaping', () => {
   it('escapes', () => {
     const html = serialize('foo', '', { foo: '</script>', bar: '&gt;' });
 
-    assert.include(html, '</script&gt;');
+    assert.include(html, '&lt;&#47;script&gt;');
     assert.include(html, '&amp;gt;');
   });
 


### PR DESCRIPTION
Enhances HTML escaping by accounting for `<` and `/`. This helps to further avoid cases where these HTML characters inputted  into Hypernova are not escaped, leading to downstream breakages in places like `JSON.parse()`.

`npm test` comes back green.

This is the first step toward packaging these changes into a new version for private release on package cloud.